### PR TITLE
Fix binary's versionning in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /go/mx-chain-go
 
 # MultiversX node
 WORKDIR /go/mx-chain-go/cmd/node
-RUN go build -i -v -ldflags="-X main.appVersion=$(git describe --tags --long --dirty)"
+RUN go build -i -v -ldflags="-X main.appVersion=$(git --git-dir /config/.git describe --tags --long --dirty)"
 RUN cp /go/pkg/mod/github.com/!elrond!network/arwen-wasm-vm@$(cat /go/mx-chain-go/go.mod | grep arwen-wasm-vm | sed 's/.* //' | tail -n 1)/wasmer/libwasmer_linux_amd64.so /lib/libwasmer_linux_amd64.so
 
 WORKDIR /config


### PR DESCRIPTION
The binary version needs to be equal to the chain version to be properly announced on the network. This PR modifys the target git repository to grab the correct version according to the mainnet Dockerfile.